### PR TITLE
Laplace typechecking

### DIFF
--- a/src/frontend/Semantic_error.mli
+++ b/src/frontend/Semantic_error.mli
@@ -17,6 +17,7 @@ val int_expected : Location_span.t -> string -> UnsizedType.t -> t
 val int_or_real_expected : Location_span.t -> string -> UnsizedType.t -> t
 val int_intarray_or_range_expected : Location_span.t -> UnsizedType.t -> t
 val int_or_real_container_expected : Location_span.t -> UnsizedType.t -> t
+val vector_expected : Location_span.t -> string -> UnsizedType.t -> t
 
 val scalar_or_type_expected :
   Location_span.t -> string -> UnsizedType.t -> UnsizedType.t -> t
@@ -90,6 +91,7 @@ val illtyped_variadic_laplace :
   -> SignatureMismatch.function_mismatch
   -> t
 
+val variadic_laplace_missing_args : Location_span.t -> t
 val nonreturning_fn_expected_returning_found : Location_span.t -> string -> t
 val nonreturning_fn_expected_nonfn_found : Location_span.t -> string -> t
 

--- a/src/frontend/SignatureMismatch.ml
+++ b/src/frontend/SignatureMismatch.ml
@@ -280,43 +280,6 @@ let check_variadic_args allow_lpdf mandatory_arg_tys mandatory_fun_arg_tys
   | (_, x) :: _ -> TypeMismatch (minimal_func_type, x, None) |> wrap_err
   | [] -> Error ([], ArgNumMismatch (List.length mandatory_arg_tys, 0))
 
-let check_laplace_variadic_args
-    (mandatory_lp_args : (UnsizedType.autodifftype * UnsizedType.t) list)
-    fun_return args =
-  let minimal_func_type =
-    UnsizedType.UFun ([], ReturnType fun_return, FnPlain, AoS) in
-  let minimal_args =
-    mandatory_lp_args @ [(UnsizedType.AutoDiffable, minimal_func_type)] in
-  let wrap_err x = Error (minimal_args, ArgError (1, x)) in
-  match args with
-  | ( _
-    , ( UnsizedType.UFun (fun_args, ReturnType return_type, suffix, _) as
-      func_type ) )
-    :: _ ->
-      (* this is not right*)
-      let functor_variadic_arg_types = fun_args in
-      let wrap_func_error x =
-        TypeMismatch (minimal_func_type, func_type, Some x) |> wrap_err in
-      let suffix = Fun_kind.without_propto suffix in
-      if suffix = FnPlain then
-        match check_same_type 1 return_type fun_return with
-        | Error _ ->
-            let () = printf "Got blah2" in
-            wrap_func_error
-              (ReturnTypeMismatch (ReturnType fun_return, ReturnType return_type)
-              )
-        | Ok _ ->
-          let expected_args =
-            (mandatory_lp_args )
-            @ functor_variadic_arg_types in
-            let () = printf "Got blah1" in
-            check_compatible_arguments 0 expected_args args
-            |> Result.map ~f:(fun x -> (func_type, x))
-            |> Result.map_error ~f:(fun x -> (expected_args, x))
-      else wrap_func_error (SuffixMismatch (FnPlain, suffix))
-  | (_, x) :: _ -> TypeMismatch (minimal_func_type, x, None) |> wrap_err
-  | [] -> Error ([], ArgNumMismatch (List.length mandatory_lp_args, 0))
-
 let pp_signature_mismatch ppf (name, arg_tys, (sigs, omitted)) =
   let open Fmt in
   let ctx = ref TypeMap.empty in

--- a/src/frontend/SignatureMismatch.mli
+++ b/src/frontend/SignatureMismatch.mli
@@ -75,18 +75,6 @@ val check_variadic_args :
       If none is found, returns [Error] of the list of args and a function_mismatch.
      *)
 
-val check_laplace_variadic_args :
-     (UnsizedType.autodifftype * UnsizedType.t) list
-  -> UnsizedType.t
-  -> (UnsizedType.autodifftype * UnsizedType.t) list
-  -> ( UnsizedType.t * Promotion.t list
-     , (UnsizedType.autodifftype * UnsizedType.t) list * function_mismatch )
-     result
-(** Check variadic function arguments.
-    If a match is found, returns [Ok] of the function type and a list of promotions (see [promote])
-    If none is found, returns [Error] of the list of args and a function_mismatch.
-   *)
-
 val pp_signature_mismatch :
      Format.formatter
   -> string

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -561,7 +561,7 @@ let rec check_fn ~is_cond_dist loc cf tenv id (tes : Ast.typed_expression list)
   else if Stan_math_signatures.is_variadic_dae_fn id.name then
     check_variadic_dae ~is_cond_dist loc cf tenv id tes
   else if Stan_math_signatures.is_variadic_laplace_fn id.name then
-    check_variadic_laplace2 ~is_cond_dist loc cf tenv id tes
+    check_variadic_laplace ~is_cond_dist loc cf tenv id tes
   else check_normal_fn ~is_cond_dist loc tenv id tes
 
 and check_reduce_sum ~is_cond_dist loc cf tenv id tes =
@@ -732,7 +732,7 @@ and peeler n lister =
  * 2. The argument order is [mandatory_lpdf_args, inits, covariance_func, covaraince_func_args...]
  * 3. The covaraince_func_args match for the covariance_func
  *)
-and check_variadic_laplace2 ~is_cond_dist (loc : Location_span.t)
+and check_variadic_laplace ~is_cond_dist (loc : Location_span.t)
     (cf : context_flags_record) (tenv : Env.t) (id : identifier)
     (tes : typed_expression list) =
   (* argument splitting *)
@@ -740,20 +740,22 @@ and check_variadic_laplace2 ~is_cond_dist (loc : Location_span.t)
     List.split_while
       ~f:(fun {emeta= {type_; _}; _} -> not (UnsizedType.is_fun_type type_))
       tes in
+  print_s [%sexp (dist_vector_args : typed_expression list)] ;
   let init_vector =
     List.last dist_vector_args
-    |> Option.value
-         ~default:(failwith "Error 1 here: No lpdf/lmpf args supplied") in
+    |> Option.value_exn ~message:"Todo failed without lpdf args" in
   let dist_args = List.drop_last_exn dist_vector_args in
   (* begin typechecking *)
   (* 1. check that the pdf/pmf this is calling is valid *)
   ignore (* ignore the result - we only want this to raise an error *)
     (* except for the possibility of promotions? *)
-    ( check_normal_fn ~is_cond_dist:false loc tenv id
+    ( check_normal_fn ~is_cond_dist:false loc tenv
+        {id with name= "poisson_log_lpmf"}
         (*placeholder: turn into actual fn id, e.g. poisson_log_lpmf *)
         dist_args
       : typed_expression ) ;
   (* 2. check that the init vector is valid *)
+  ignore (init_vector : typed_expression) ;
   (* TODO similar to check_expression_of_int_type *)
   (* 3. check variadic function, similar to ODE/DAE/reduce_sum *)
 
@@ -763,15 +765,14 @@ and check_variadic_laplace2 ~is_cond_dist (loc : Location_span.t)
       Stan_math_signatures.variadic_laplace_tol_arg_types
     else [] in
   let mandatory_lp_arg_types : (UnsizedType.autodifftype * UnsizedType.t) list =
-    Stan_math_signatures.variadic_laplace_mandatory_arg_types id.name
-    @ [(UnsizedType.AutoDiffable, UnsizedType.UVector)]
+    Stan_math_signatures.variadic_laplace_mandatory_arg_types
     @ optional_tol_args in
   let matching remaining_exprs Env.{type_= ftype; _} =
     let arg_types =
       (calculate_autodifftype cf Functions ftype, ftype)
       :: get_arg_types remaining_exprs in
-    (* Do we really need a new variadic args checker? why doesn't the prior one work? *)
-    SignatureMismatch.check_laplace_variadic_args mandatory_lp_arg_types
+    SignatureMismatch.check_variadic_args false mandatory_lp_arg_types
+      Stan_math_signatures.variadic_laplace_mandatory_fun_args
       Stan_math_signatures.variadic_laplace_fun_return_type arg_types in
   match fn_variadic_args with
   | {expr= Variable fname; _} :: remaining_es -> (
@@ -800,7 +801,8 @@ and check_variadic_laplace2 ~is_cond_dist (loc : Location_span.t)
   | _ ->
       let () = printf "I happened1\n" in
       let expected_args, err =
-        SignatureMismatch.check_laplace_variadic_args mandatory_lp_arg_types
+        SignatureMismatch.check_variadic_args false mandatory_lp_arg_types
+          Stan_math_signatures.variadic_laplace_mandatory_fun_args
           Stan_math_signatures.variadic_laplace_fun_return_type
           (get_arg_types tes)
         |> Result.error |> Option.value_exn in
@@ -809,75 +811,6 @@ and check_variadic_laplace2 ~is_cond_dist (loc : Location_span.t)
         expected_args err
       |> error
 
-(*
-and check_variadic_laplace ~is_cond_dist (loc : Location_span.t)
-    (cf : context_flags_record) (tenv : Env.t) (id : identifier)
-    (tes : (typed_expr_meta, fun_kind) expr_with list) =
-  let optional_tol_mandatory_args :
-      (UnsizedType.autodifftype * UnsizedType.t) list =
-    if Stan_math_signatures.is_variadic_laplace_tol_fn id.name then
-      Stan_math_signatures.variadic_laplace_tol_arg_types
-    else [] in
-  let mandatory_arg_types : (UnsizedType.autodifftype * UnsizedType.t) list =
-    Stan_math_signatures.variadic_laplace_mandatory_arg_types id.name
-    @ optional_tol_mandatory_args in
-  let fail () =
-    let () = printf "I happened1\n" in
-    let expected_args, err =
-      SignatureMismatch.check_laplace_variadic_args mandatory_arg_types
-        Stan_math_signatures.variadic_laplace_fun_return_type
-        (get_arg_types tes)
-      |> Result.error |> Option.value_exn in
-    Semantic_error.illtyped_variadic_laplace loc id.name
-      (List.map ~f:type_of_expr_typed tes)
-      expected_args err
-    |> error in
-  let matching remaining_exprs Env.{type_= ftype; _} =
-    let arg_types =
-      (calculate_autodifftype cf Functions ftype, ftype)
-      :: get_arg_types remaining_exprs in
-    SignatureMismatch.check_laplace_variadic_args []
-      Stan_math_signatures.variadic_laplace_fun_return_type arg_types in
-  let peeler n lister =
-    let rec peeler_impl n (left_list : 'a list) (right_list : 'a list) =
-      if n = 0 then (left_list, right_list)
-      else
-        peeler_impl (n - 1)
-          (List.hd_exn right_list :: left_list)
-          (List.tl_exn right_list) in
-    peeler_impl n [] lister in
-  let _, min_tess = peeler 2 tes in
-  match min_tess with
-  | {expr= Variable covar_fun; emeta= covar_meta}
-    :: {emeta= theta0_meta; _} :: tail_exprs
-    when UnsizedType.is_fun_type covar_meta.type_
-         && UnsizedType.is_eigen_type theta0_meta.type_ -> (
-      let () = printf "I happened2\n" in
-      match
-        find_matching_first_order_fn tenv (matching tail_exprs) covar_fun
-      with
-      | SignatureMismatch.UniqueMatch (ftype, promotions) ->
-          let () = printf "I happened3\n" in
-          let tes2 =
-            make_function_variable cf loc covar_fun ftype :: tail_exprs in
-          mk_typed_expression
-            ~expr:
-              (mk_fun_app ~is_cond_dist
-                 (StanLib FnPlain, id, Promotion.promote_list tes2 promotions) )
-            ~ad_level:(expr_ad_lub tes)
-            ~type_:Stan_math_signatures.variadic_laplace_return_type ~loc
-      | AmbiguousMatch ps ->
-          let () = printf "I happened4\n" in
-          Semantic_error.ambiguous_function_promotion loc covar_fun.name None ps
-          |> error
-      | SignatureErrors (expected_args, err) ->
-          let () = printf "I happened5\n" in
-          Semantic_error.illtyped_variadic_laplace loc id.name
-            (List.map ~f:type_of_expr_typed tes)
-            expected_args err
-          |> error )
-  | _ -> fail ()
-*)
 and check_funapp loc cf tenv ~is_cond_dist id (es : Ast.typed_expression list) =
   let name_check =
     if is_cond_dist then verify_conddist_name else verify_fn_conditioning in

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -748,8 +748,10 @@ and check_variadic_laplace2 ~is_cond_dist (loc : Location_span.t)
   (* begin typechecking *)
   (* 1. check that the pdf/pmf this is calling is valid *)
   ignore (* ignore the result - we only want this to raise an error *)
+    (* except for the possibility of promotions? *)
     ( check_normal_fn ~is_cond_dist:false loc tenv id
-        (*placeholder: turn into actual fn id *) dist_args
+        (*placeholder: turn into actual fn id, e.g. poisson_log_lpmf *)
+        dist_args
       : typed_expression ) ;
   (* 2. check that the init vector is valid *)
   (* TODO similar to check_expression_of_int_type *)
@@ -780,7 +782,10 @@ and check_variadic_laplace2 ~is_cond_dist (loc : Location_span.t)
         mk_typed_expression
           ~expr:
             (mk_fun_app ~is_cond_dist
-               (StanLib FnPlain, id, Promotion.promote_list tes2 promotions) )
+               ( StanLib FnPlain
+               , id
+               , dist_args
+                 @ (init_vector :: Promotion.promote_list tes2 promotions) ) )
           ~ad_level:(expr_ad_lub tes) ~type_:UnsizedType.UReal ~loc
     | AmbiguousMatch ps ->
         let () = printf "I happened4\n" in

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -740,7 +740,6 @@ and check_variadic_laplace ~is_cond_dist (loc : Location_span.t)
     List.split_while
       ~f:(fun {emeta= {type_; _}; _} -> not (UnsizedType.is_fun_type type_))
       tes in
-  print_s [%sexp (dist_vector_args : typed_expression list)] ;
   let init_vector =
     match List.last dist_vector_args with
     | Some v -> v
@@ -782,7 +781,6 @@ and check_variadic_laplace ~is_cond_dist (loc : Location_span.t)
   | {expr= Variable fname; _} :: remaining_es -> (
     match find_matching_first_order_fn tenv (matching remaining_es) fname with
     | SignatureMismatch.UniqueMatch (ftype, promotions) ->
-        let () = printf "I happened3\n" in
         let tes2 = make_function_variable cf loc fname ftype :: remaining_es in
         mk_typed_expression
           ~expr:
@@ -793,17 +791,14 @@ and check_variadic_laplace ~is_cond_dist (loc : Location_span.t)
                  @ (init_vector :: Promotion.promote_list tes2 promotions) ) )
           ~ad_level:(expr_ad_lub tes) ~type_:UnsizedType.UReal ~loc
     | AmbiguousMatch ps ->
-        let () = printf "I happened4\n" in
         Semantic_error.ambiguous_function_promotion loc fname.name None ps
         |> error
     | SignatureErrors (expected_args, err) ->
-        let () = printf "I happened5\n" in
         Semantic_error.illtyped_variadic_laplace loc id.name
           (List.map ~f:type_of_expr_typed tes)
           expected_args err
         |> error )
   | _ ->
-      let () = printf "I happened1\n" in
       let expected_args, err =
         SignatureMismatch.check_variadic_args false mandatory_lp_arg_types
           Stan_math_signatures.variadic_laplace_mandatory_fun_args

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -238,18 +238,10 @@ let is_variadic_dae_fn f = Set.mem variadic_dae_fns f
 let is_variadic_dae_tol_fn f =
   is_variadic_dae_fn f && String.is_suffix f ~suffix:dae_tolerances_suffix
 
-let is_variadic_laplace_fn_defs =
-  String.Set.of_list
-    [ "laplace_marginal_neg_binomial_2_log_lpmf"
-    ; "laplace_marginal_bernoulli_logit_lpmf"
-    ; "laplace_marginal_poisson_log_lpmf" ]
-
 let variadic_laplace_mandatory_arg_types = []
 
-(* TODO does this catch tolerances as well?
-   What about rngs?
-*)
-let is_variadic_laplace_fn x = Set.mem is_variadic_laplace_fn_defs x
+(* TODO What about rngs? *)
+let is_variadic_laplace_fn x = String.is_prefix ~prefix:"laplace_marginal" x
 
 let is_variadic_laplace_tol_fn x =
   String.is_prefix ~prefix:"laplace_marginal" x

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -244,24 +244,9 @@ let is_variadic_laplace_fn_defs =
     ; "laplace_marginal_bernoulli_logit_lpmf"
     ; "laplace_marginal_poisson_log_lpmf" ]
 
-let laplace_mandatory_args_map =
-  Map.of_alist_exn
-    (module String)
-    [ ( "neg_binomial_2_log"
-      , [ (UnsizedType.AutoDiffable, UnsizedType.UArray UInt)
-        ; (AutoDiffable, UArray UInt) ] )
-    ; ( "bernoulli_logit"
-      , [(AutoDiffable, UArray UInt); (AutoDiffable, UArray UInt)] )
-    ; ("poisson_log", [(AutoDiffable, UArray UInt); (AutoDiffable, UArray UInt)]) ]
+let variadic_laplace_mandatory_arg_types = []
 
-let variadic_laplace_mandatory_arg_types name =
-  let contains_substring search =
-    String.substr_index ~pattern:search name <> None in
-  let sub_map =
-    Map.filter_keys laplace_mandatory_args_map ~f:contains_substring in
-  let blah = Map.find sub_map (List.hd_exn (Map.keys sub_map)) in
-  match blah with Some x -> x | None -> []
-
+(* TODO does this catch tolerances as well?*)
 let is_variadic_laplace_fn x = Set.mem is_variadic_laplace_fn_defs x
 
 let is_variadic_laplace_tol_fn x =

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -246,7 +246,9 @@ let is_variadic_laplace_fn_defs =
 
 let variadic_laplace_mandatory_arg_types = []
 
-(* TODO does this catch tolerances as well?*)
+(* TODO does this catch tolerances as well?
+   What about rngs?
+*)
 let is_variadic_laplace_fn x = Set.mem is_variadic_laplace_fn_defs x
 
 let is_variadic_laplace_tol_fn x =
@@ -2097,6 +2099,8 @@ let () =
   add_unqualified ("zeros_array", ReturnType (UArray UReal), [UInt], SoA) ;
   add_unqualified ("zeros_row_vector", ReturnType URowVector, [UInt], SoA) ;
   add_unqualified ("zeros_vector", ReturnType UVector, [UInt], SoA) ;
+  (* BMW: This seems weird to me, we don't add other special-cased varadic functions to the table
+  *)
   (* Embedded Laplace approximation *)
   add_qualified
     (* function signature with x as an array of vectors *)

--- a/test/integration/good/function-signatures/math/functions/laplace_marginal_poisson_log.stan
+++ b/test/integration/good/function-signatures/math/functions/laplace_marginal_poisson_log.stan
@@ -18,5 +18,6 @@ parameters {
 model {
   target +=
     laplace_marginal_poisson_log_lpmf(y | n_samples, theta0, covar_fun, alpha);
+  y ~ laplace_marginal_poisson_log(n_samples, theta0, covar_fun, alpha);
 }
 

--- a/test/integration/good/function-signatures/math/functions/laplace_marginal_poisson_log.stan
+++ b/test/integration/good/function-signatures/math/functions/laplace_marginal_poisson_log.stan
@@ -19,5 +19,15 @@ model {
   target +=
     laplace_marginal_poisson_log_lpmf(y | n_samples, theta0, covar_fun, alpha);
   y ~ laplace_marginal_poisson_log(n_samples, theta0, covar_fun, alpha);
+
+
+  // each of these produces a unique typeerror
+  // target += laplace_marginal_poisson_log_lpmf(y , theta0, covar_fun, alpha);
+  // target += laplace_marginal_poisson_log_lpmf( covar_fun, alpha);
+  // target += laplace_marginal_poisson_log_lpmf(y | n_samples, theta0, covar_fun);
+  // target += laplace_marginal_poisson_log_lpmf(y | n_samples, theta0, covar_fun, alpha, alpha);
+  // this style also does
+  // y ~ laplace_marginal_poisson_log(n_samples, theta0, covar_fun);
+
 }
 


### PR DESCRIPTION
This gets the basics done for the `laplace_marginal_poisson_log.stan` test. Removing or adding arguments to make the function call invalid produces nice errors.

Some questions/comments:
1. This needs a lot more testing, especially of the tolerance versions and for intentionally bad/malformed inputs. Most of what I've done is just add or remove arguments to the 1 working test.
2. The fact that these are added to stan math signatures seems wrong to me - we don't add reduce_sum to the list, for example
3. I think it will be reasonable to adapt the existing code to the _rng versions if needed, but note that currently it does not.